### PR TITLE
Add Yargs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+build/
+.gitignore
+jest.config.js
+scripts/
+node_modules/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true,
+    "jest/globals": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "plugin:jest/recommended",
+    "plugin:jest/style"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint", "prettier", "jest"],
+  "rules": {
+    "prettier/prettier": ["error"],
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/explicit-module-return-type": "off"
+  }
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 70,
+  "disableLanguages": []
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  roots: ["<rootDir>"],
+  testMatch: [
+    "**/__tests__/**/*.+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)",
+  ],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
+};

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,55 +1,59 @@
 #!/usr/bin/env node
 
-import { exec } from "child_process";
-import * as path from "path";
-import defaultOptions from "./configs/default.config";
-import packageJSONTemplate from "./templates/package.json";
+import { exec } from 'child_process';
+import * as path from 'path';
+import defaultOptions from './configs/default.config';
+import packageJSONTemplate from './templates/package.json';
 import {
   copyDir,
   mkDir,
+  writeFile,
   writeObjectToJSONFile,
-} from "./services/utils.service";
-import { Options } from "./types/types";
-import devDependencies from "./configs/devDependencies";
-import { getArgs } from "./services/args.service";
+} from './services/utils.service';
+import { Options } from './types/types';
+import devDependencies from './configs/devDependencies';
+import { getArgs, getArgValues } from './services/args.service';
 
 const args = getArgs(process.argv.slice(2)).argv;
-
-console.log(args);
-const name = args[0];
-
-const userOptions: Options = { name };
-const options: Options = { ...defaultOptions, ...userOptions };
+console.log('args', args);
+const options: Options = getArgValues(process.argv.slice(2));
+console.log('options', options);
+// process.exit();
 
 const packageJSON = packageJSONTemplate;
 
-console.log("testing new  scripts");
+console.log('testing new  scripts');
 
-copyDir(path.resolve(__dirname, "./templates"), options.projectDir);
+copyDir(path.resolve(__dirname, './templates'), options.projectDir);
 
 packageJSON.name = options.name;
 
-writeObjectToJSONFile(packageJSON, options.projectDir, "package");
+writeObjectToJSONFile(packageJSON, options.projectDir, 'package');
 
 // creating tests directory
-mkDir(options.projectDir, "__tests__");
+mkDir(options.projectDir, '__tests__');
 
 // creating lib directory
-mkDir(options.projectDir, "lib");
+mkDir(options.projectDir, 'lib');
 
-console.log("Installing the following dev dependencies:");
+// writing entry point
+writeFile('ts')('', `${options.projectDir}/lib`, options.entryPoint);
+
+console.log('Installing the following dev dependencies:');
 
 devDependencies.forEach((dep) => {
   console.log(dep);
 });
 
-if (process.env.NO_INSTALL === "true") {
-  console.log("SKIPPING DEPENDENCY INSTALLATION, DEVELOPMENT ENV");
+if (process.env.NO_INSTALL === 'true') {
+  console.log('SKIPPING DEPENDENCY INSTALLATION, DEVELOPMENT ENV');
   process.exit();
 }
 
 exec(
-  `cd ${options.projectDir} && npm install ${devDependencies.join(" ")} -D`,
+  `cd ${options.projectDir} && npm install ${devDependencies.join(
+    ' ',
+  )} -D`,
   (error, stdout, stderr) => {
     if (error) {
       console.log(`error: ${error.message}`);
@@ -60,7 +64,7 @@ exec(
       return;
     }
     console.log(`stdout: ${stdout}`);
-  }
+  },
 );
 
 exec(`pwd`, (error, stdout, stderr) => {
@@ -76,5 +80,7 @@ exec(`pwd`, (error, stdout, stderr) => {
 });
 
 console.log(
-  `Project "${options.name}" has been initialied in directory ${process.cwd()}`
+  `Project "${
+    options.name
+  }" has been initialied in directory ${process.cwd()}`,
 );

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -11,9 +11,11 @@ import {
 } from "./services/utils.service";
 import { Options } from "./types/types";
 import devDependencies from "./configs/devDependencies";
+import { getArgs } from "./services/args.service";
 
-const args = process.argv.slice(2);
+const args = getArgs(process.argv.slice(2)).argv;
 
+console.log(args);
 const name = args[0];
 
 const userOptions: Options = { name };

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -15,14 +15,10 @@ import devDependencies from './configs/devDependencies';
 import { getArgs, getArgValues } from './services/args.service';
 
 const args = getArgs(process.argv.slice(2)).argv;
-console.log('args', args);
 const options: Options = getArgValues(process.argv.slice(2));
-console.log('options', options);
 // process.exit();
-
+mkDir(options.projectDir);
 const packageJSON = packageJSONTemplate;
-
-console.log('testing new  scripts');
 
 copyDir(path.resolve(__dirname, './templates'), options.projectDir);
 

--- a/lib/configs/default.config.ts
+++ b/lib/configs/default.config.ts
@@ -1,12 +1,13 @@
-import * as path from "path";
-import { ReadOnlyOptions } from "../types/types";
+import * as path from 'path';
+import { ReadOnlyOptions } from '../types/types';
 
 const defaultPath =
-  process.env.NODE_ENV === "development" ? "./dev_test_dir" : "./";
+  process.env.NODE_ENV === 'development' ? './dev_test_dir' : './';
 
 const defaultOptions: ReadOnlyOptions = {
-  name: "test name",
+  name: 'test name',
   projectDir: path.join(defaultPath),
+  entryPoint: 'index',
 };
 
 export default defaultOptions;

--- a/lib/configs/options.config.ts
+++ b/lib/configs/options.config.ts
@@ -1,6 +1,6 @@
 import { OptionConfig } from '../types/types';
 
-const optionConfig: OptionConfig = {
+const optionConfig: OptionConfig = <OptionConfig>{
   name: {
     name: 'n',
     alias: 'name',

--- a/lib/configs/options.config.ts
+++ b/lib/configs/options.config.ts
@@ -1,0 +1,8 @@
+import { OptionConfig } from "../types/types";
+
+const optionConfig: OptionConfig = {
+  name: { alias: "n", type: "string", demandOption: true },
+  projectDir: { alias: "dir", type: "string", demandOption: false },
+};
+
+export default optionConfig;

--- a/lib/configs/options.config.ts
+++ b/lib/configs/options.config.ts
@@ -1,8 +1,24 @@
-import { OptionConfig } from "../types/types";
+import { OptionConfig } from '../types/types';
 
 const optionConfig: OptionConfig = {
-  name: { alias: "n", type: "string", demandOption: true },
-  projectDir: { alias: "dir", type: "string", demandOption: false },
+  name: {
+    name: 'n',
+    alias: 'name',
+    type: 'string',
+    demandOption: true,
+  },
+  projectDir: {
+    name: 'd',
+    alias: 'dir',
+    type: 'string',
+    demandOption: false,
+  },
+  entryPoint: {
+    name: 'f',
+    alias: 'file',
+    type: 'string',
+    demandOption: false,
+  },
 };
 
 export default optionConfig;

--- a/lib/services/args.service.ts
+++ b/lib/services/args.service.ts
@@ -1,9 +1,16 @@
-import yargs from 'yargs';
+import yargs, { Options as YOptions, Argv } from 'yargs';
 import defaultOptions from '../configs/default.config';
 import optionConfig from '../configs/options.config';
-import { OptionConfig } from '../types/types';
+import { OptionConfig, OptionSetting, Options } from '../types/types';
 
-const mapOptions = (defaultOptions, options): OptionConfig => {
+interface YargsOptions {
+  [key: string]: YOptions;
+}
+
+const mapOptions = (
+  defaultOptions,
+  options: OptionConfig,
+): OptionConfig => {
   return Object.keys(options).reduce(
     (opts: OptionConfig, val: string) => {
       opts[val] = options[val];
@@ -18,7 +25,53 @@ const mapOptions = (defaultOptions, options): OptionConfig => {
 };
 
 const optionsMap = mapOptions(defaultOptions, optionConfig);
+const mapToYargs = (options: OptionConfig): YargsOptions => {
+  return Object.keys(options).reduce((opt: YargsOptions, val) => {
+    const obj: OptionSetting = { ...options[val] };
+    const { name } = obj;
+    delete obj.name;
+    const newObject: YOptions = {
+      ...obj,
+    };
 
-export const getArgs = (args: string[]) => {
-  return yargs(args).options({ name: { alias: 'n' } });
+    opt[name] = newObject;
+    return opt;
+  }, <YargsOptions>{});
+};
+
+const yargsOpts: YargsOptions = mapToYargs(optionsMap);
+
+const mapYargsToOptions = (options: Argv): Options => {
+  const argv = options.argv;
+  if (typeof argv._[0] !== 'string' && argv._.length > 0) {
+    throw new Error('First argument must be string or left blank');
+  }
+  const outOpts: Options = {
+    name: argv._[0],
+  };
+
+  return Object.keys(argv).reduce((opts, val) => {
+    const yObj = argv[val];
+    const key = Object.keys(optionConfig).find(
+      (k) => val === optionConfig[k]?.alias,
+    );
+    if (key !== undefined && opts[key] === undefined) {
+      opts[key] = yObj;
+    }
+
+    return opts;
+  }, <Options>outOpts);
+};
+
+export const getArgs = (args: string[]): Argv => {
+  const yargsOut = yargs(args).options(yargsOpts);
+  return yargsOut;
+};
+
+export const getOptions = (args: Argv): Options => {
+  return mapYargsToOptions(args);
+};
+
+export const getArgValues = (args: string[]): Options => {
+  return mapYargsToOptions(getArgs(args));
 };

--- a/lib/services/args.service.ts
+++ b/lib/services/args.service.ts
@@ -1,0 +1,24 @@
+import yargs from 'yargs';
+import defaultOptions from '../configs/default.config';
+import optionConfig from '../configs/options.config';
+import { OptionConfig } from '../types/types';
+
+const mapOptions = (defaultOptions, options): OptionConfig => {
+  return Object.keys(options).reduce(
+    (opts: OptionConfig, val: string) => {
+      opts[val] = options[val];
+
+      if (defaultOptions[val]) {
+        opts[val].default = defaultOptions[val];
+      }
+      return opts;
+    },
+    <OptionConfig>{},
+  );
+};
+
+const optionsMap = mapOptions(defaultOptions, optionConfig);
+
+export const getArgs = (args: string[]) => {
+  return yargs(args).options({ name: { alias: 'n' } });
+};

--- a/lib/services/args.service.ts
+++ b/lib/services/args.service.ts
@@ -43,10 +43,12 @@ const yargsOpts: YargsOptions = mapToYargs(optionsMap);
 
 const mapYargsToOptions = (options: Argv): Options => {
   const argv = options.argv;
+  // @ts-ignore
   if (typeof argv._[0] !== 'string' && argv._.length > 0) {
     throw new Error('First argument must be string or left blank');
   }
   const outOpts: Options = {
+    // @ts-ignore
     name: argv._[0],
   };
 

--- a/lib/services/utils.service.ts
+++ b/lib/services/utils.service.ts
@@ -1,10 +1,12 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from 'fs';
+import * as path from 'path';
 
 export const writeFile =
   (
     extension: string,
-    transform?: <T = any>(contents: T) => string | NodeJS.ArrayBufferView
+    transform: <T = any>(
+      contents: T,
+    ) => string | NodeJS.ArrayBufferView = <T>(contents) => contents,
   ) =>
   (contents: any, filePath: string, fileName: string) => {
     const transformedContents = transform(contents);
@@ -13,8 +15,8 @@ export const writeFile =
     fs.writeFileSync(targetDir, transformedContents);
     return transformedContents;
   };
-export const writeObjectToJSONFile = writeFile("json", (content) =>
-  JSON.stringify(content, null, 2)
+export const writeObjectToJSONFile = writeFile('json', (content) =>
+  JSON.stringify(content, null, 2),
 );
 
 export const loadJSONTemplateFiles = (dir: string) => {
@@ -31,16 +33,17 @@ export const mkDir = (...dirPath: string[]) => {
 export const copyDir = (copyDir: string, targetDir: string): void => {
   const files = fs.readdirSync(path.resolve(__dirname, copyDir));
 
-  for (let file of files) {
+  for (const file of files) {
     fs.copyFileSync(
       path.resolve(__dirname, copyDir, file),
-      path.resolve(targetDir, file)
+      path.resolve(targetDir, file),
     );
     console.log(
-      `copied from ${path.resolve(__dirname, copyDir, file)} to ${path.resolve(
-        targetDir,
-        file
-      )}`
+      `copied from ${path.resolve(
+        __dirname,
+        copyDir,
+        file,
+      )} to ${path.resolve(targetDir, file)}`,
     );
   }
 };

--- a/lib/services/utils.service.ts
+++ b/lib/services/utils.service.ts
@@ -26,7 +26,7 @@ export const loadJSONTemplateFiles = (dir: string) => {
 
 export const mkDir = (...dirPath: string[]) => {
   if (!fs.existsSync(path.join(...dirPath))) {
-    fs.mkdirSync(path.join(...dirPath));
+    fs.mkdirSync(path.join(...dirPath), { recursive: true });
   }
 };
 

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -1,6 +1,19 @@
-export interface Options {
+export type Options = {
   name: string;
   projectDir?: string;
-}
+  entryPoint?: string;
+};
 
 export interface ReadOnlyOptions extends Readonly<Options> {}
+
+type OptionSetting = {
+  type: string;
+  default?: any;
+  demandOption: boolean;
+  choices?: string[];
+  alias?: string;
+};
+
+export type OptionConfig = {
+  [Properties in keyof Options]: OptionSetting;
+};

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -1,17 +1,18 @@
-export type Options = {
+export interface Options extends Object {
   name: string;
   projectDir?: string;
   entryPoint?: string;
-};
+}
 
 export interface ReadOnlyOptions extends Readonly<Options> {}
 
-type OptionSetting = {
-  type: string;
+export type OptionSetting = {
+  type: 'boolean' | 'number' | 'string';
   default?: any;
-  demandOption: boolean;
+  demandOption?: boolean;
   choices?: string[];
   alias?: string;
+  name: string;
 };
 
 export type OptionConfig = {


### PR DESCRIPTION
This pr contains logic for using yargs to parse CLI arguments, mapping our current options object to a yargs object, and mapping the yargs output back into an options object. 

The purpose of this is to maintain a common interface with our Options when used in the main body of the CLI. We want to decouple the cli args parsing logic from the file creation logic. This way we can easily extend our options interface or swap out our CLI parsing logic without changing the main application. 

This PR is successful in doing this because the main body of CLI.js did not need to change in order to accommodate the entirely new Yargs CLI parsing tooling and we were able to easily extend the Options available to include the entry point. 

A single point of complexity that may need to be addressed is we have a separate options config, which configures our options object to work in a way that yargs can interpret it. This could potentially be merged with the default options, but currently I like having default Options and Options as separate entities, in case we need to change the option settings. It is a little extra work when adding a new option, but TS typechecking should catch any mismatch between the options settings and the options interface. 